### PR TITLE
Atualiza imagem base para ubuntu:jammy para suportar Biopython 1.84

### DIFF
--- a/images/machado/machado.Dockerfile
+++ b/images/machado/machado.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ARG MACHADO_SOURCE
 ARG USER


### PR DESCRIPTION
### Título do PR:
**Atualiza imagem base para `ubuntu:jammy` para suportar Biopython 1.84**

### Descrição:
Ao tentar subir o container, ocorre um erro porque o `biopython>=1.84` (biblioteca utilizada no `setup.py` do repositório do [machado](https://github.com/lmb-embrapa/machado/blob/master/setup.py)) requer **Python >= 3.9**, mas a imagem `ubuntu:focal` (atualmente usada) vem com **Python 3.8** por padrão.

Para resolver, atualizei a imagem base para `ubuntu:jammy`, que inclui **Python 3.10**. Isso permite a instalação do `biopython>=1.84` sem erros.

### Como testar:
1. Utilize o Dockerfile atualizado.
2. Execute o build:
   ```bash
   docker-compose up --build
   ```